### PR TITLE
PackageInstaller: Add tint mode to icons

### DIFF
--- a/src/com/android/packageinstaller/permission/utils/Utils.java
+++ b/src/com/android/packageinstaller/permission/utils/Utils.java
@@ -25,6 +25,7 @@ import android.content.pm.ResolveInfo;
 import android.content.res.Resources;
 import android.content.res.Resources.Theme;
 import android.graphics.drawable.Drawable;
+import android.graphics.PorterDuff;
 import android.util.ArraySet;
 import android.util.Log;
 import android.util.TypedValue;
@@ -112,6 +113,7 @@ public final class Utils {
         theme.resolveAttribute(attr, typedValue, true);
         icon = icon.mutate();
         icon.setTint(context.getColor(typedValue.resourceId));
+        icon.setTintMode(PorterDuff.Mode.SRC_ATOP);
         return icon;
     }
 


### PR DESCRIPTION
This allows custom icons can show in permissions settings

Change-Id: I8fa2360d1340cb825938f4c820d99c98d3037baa
Signed-off-by: Bryan Owens <djbryan3540@gmail.com>